### PR TITLE
Reconnect after heartbeat timeout

### DIFF
--- a/Sources/SwiftPhoenixClient/Socket.swift
+++ b/Sources/SwiftPhoenixClient/Socket.swift
@@ -792,6 +792,9 @@ public class Socket: PhoenixTransportDelegate {
   }
   
   public func onClose(code: Int) {
+    if code == CloseCode.normal.rawValue && self.closingAbnormally {
+      self.logItems("transport", "server confirmed client-initiated abnormal close")
+    }
     self.closeWasClean = code != CloseCode.abnormal.rawValue
     self.onConnectionClosed(code: code)
   }

--- a/Sources/SwiftPhoenixClient/Socket.swift
+++ b/Sources/SwiftPhoenixClient/Socket.swift
@@ -154,12 +154,9 @@ public class Socket: PhoenixTransportDelegate {
   
   /// Timer to use when attempting to reconnect
   var reconnectTimer: TimeoutTimer
-  
-  /// True if the Socket closed cleaned. False if not (connection timeout, heartbeat, etc)
-  var closeWasClean: Bool = false
 
-  /// True if the Socket is being closed abnormally
-  var closingAbnormally: Bool = false
+  /// Close status
+  var closeStatus: CloseStatus = .unknown
   
   /// The connection to the server
   var connection: PhoenixTransport? = nil
@@ -242,9 +239,8 @@ public class Socket: PhoenixTransportDelegate {
     // Do not attempt to reconnect if the socket is currently connected
     guard !isConnected else { return }
     
-    // Reset the clean close flags when attempting to connect
-    self.closeWasClean = false
-    self.closingAbnormally = false
+    // Reset the close status when attempting to connect
+    self.closeStatus = .unknown
 
     // We need to build this right before attempting to connect as the
     // parameters could be built upon demand and change over time
@@ -272,8 +268,7 @@ public class Socket: PhoenixTransportDelegate {
   public func disconnect(code: CloseCode = CloseCode.normal,
                          callback: (() -> Void)? = nil) {
     // The socket was closed cleanly by the User
-    self.closeWasClean = true
-    self.closingAbnormally = false
+    self.closeStatus = .clean
     
     // Reset any reconnects and teardown the socket connection
     self.reconnectTimer.reset()
@@ -577,9 +572,8 @@ public class Socket: PhoenixTransportDelegate {
   internal func onConnectionOpen() {
     self.logItems("transport", "Connected to \(endPoint)")
     
-    // Reset the close flags now that the socket has been connected
-    self.closeWasClean = false
-    self.closingAbnormally = false
+    // Reset the close status now that the socket has been connected
+    self.closeStatus = .unknown
 
     // Send any messages that were waiting for a connection
     self.flushSendBuffer()
@@ -605,11 +599,8 @@ public class Socket: PhoenixTransportDelegate {
     
     // Only attempt to reconnect if the socket did not close normally,
     // or if it was closed abnormally but on client side (e.g. due to heartbeat timeout)
-    if (!self.closeWasClean || self.closingAbnormally) {
+    if (self.closeStatus.shouldReconnect) {
       self.reconnectTimer.scheduleTimeout()
-
-      // Reset the transient client-initiated abnormal close flag
-      self.closingAbnormally = false
     }
     
     self.stateChangeCallbacks.close.forEach({ $0.callback.call() })
@@ -765,12 +756,15 @@ public class Socket: PhoenixTransportDelegate {
   }
   
   internal func abnormalClose(_ reason: String) {
-    self.closingAbnormally = true
+    self.closeStatus = .abnormal
     
     /*
      We use NORMAL here since the client is the one determining to close the
-     connection. However, we keep a flag `closingAbnormally` set to true so that
+     connection. However, we set to close status to abnormal so that
      the client knows that it should attempt to reconnect.
+
+     If the server subsequently acknowledges with code 1000 (normal close),
+     the socket will keep the `.abnormal` close status and trigger a reconnection.
      */
     self.connection?.disconnect(code: CloseCode.normal.rawValue, reason: reason)
   }
@@ -792,10 +786,10 @@ public class Socket: PhoenixTransportDelegate {
   }
   
   public func onClose(code: Int) {
-    if code == CloseCode.normal.rawValue && self.closingAbnormally {
+    if code == CloseCode.normal.rawValue && self.closeStatus == .abnormal {
       self.logItems("transport", "server confirmed client-initiated abnormal close")
     }
-    self.closeWasClean = code != CloseCode.abnormal.rawValue
+    self.closeStatus.update(transportCloseCode: code)
     self.onConnectionClosed(code: code)
   }
 }
@@ -811,5 +805,52 @@ extension Socket {
     case normal = 1000
 
     case goingAway = 1001
+  }
+}
+
+
+//----------------------------------------------------------------------
+// MARK: - Close Status
+//----------------------------------------------------------------------
+extension Socket {
+  /// Indicates the different closure states a socket can be in.
+  enum CloseStatus {
+    /// Undetermined closure state
+    case unknown
+    /// A clean closure requested either by the client or the server
+    case clean
+    /// An abnormal closure requested by the client
+    case abnormal
+
+    init(closeCode: Int) {
+        switch closeCode {
+        case CloseCode.abnormal.rawValue:
+          self = .abnormal
+        default:
+          self = .clean
+        }
+    }
+
+    mutating func update(transportCloseCode: Int) {
+        switch self {
+        case .unknown, .clean:
+          // Allow transport layer to override these statuses.
+          self = .init(closeCode: transportCloseCode)
+        case .abnormal:
+          // Do not allow transport layer to override the abnormal close status.
+          // The socket itself should reset it on the next connection attempt.
+          // See `Socket.abnormalClose(_:)` for more information.
+          break
+        }
+    }
+
+    var shouldReconnect: Bool {
+      switch self {
+      case .unknown, .abnormal:
+        return true
+      case .clean:
+        return false
+      }
+    }
   }
 }

--- a/Sources/SwiftPhoenixClient/Socket.swift
+++ b/Sources/SwiftPhoenixClient/Socket.swift
@@ -821,29 +821,29 @@ extension Socket {
     case clean
     /// An abnormal closure requested by the client
     case abnormal
-
+    
     init(closeCode: Int) {
-        switch closeCode {
-        case CloseCode.abnormal.rawValue:
-          self = .abnormal
-        default:
-          self = .clean
-        }
+      switch closeCode {
+      case CloseCode.abnormal.rawValue:
+        self = .abnormal
+      default:
+        self = .clean
+      }
     }
-
+    
     mutating func update(transportCloseCode: Int) {
-        switch self {
-        case .unknown, .clean:
-          // Allow transport layer to override these statuses.
-          self = .init(closeCode: transportCloseCode)
-        case .abnormal:
-          // Do not allow transport layer to override the abnormal close status.
-          // The socket itself should reset it on the next connection attempt.
-          // See `Socket.abnormalClose(_:)` for more information.
-          break
-        }
+      switch self {
+      case .unknown, .clean:
+        // Allow transport layer to override these statuses.
+        self = .init(closeCode: transportCloseCode)
+      case .abnormal:
+        // Do not allow transport layer to override the abnormal close status.
+        // The socket itself should reset it on the next connection attempt.
+        // See `Socket.abnormalClose(_:)` for more information.
+        break
+      }
     }
-
+    
     var shouldReconnect: Bool {
       switch self {
       case .unknown, .abnormal:

--- a/Tests/Mocks/MockableClass.generated.swift
+++ b/Tests/Mocks/MockableClass.generated.swift
@@ -660,11 +660,11 @@ class SocketMock: Socket {
         set(value) { underlyingReconnectTimer = value }
     }
     var underlyingReconnectTimer: (TimeoutTimer)!
-    override var closeWasClean: Bool {
-        get { return underlyingCloseWasClean }
-        set(value) { underlyingCloseWasClean = value }
+    override var closeStatus: CloseStatus {
+      get { return underlyingCloseStatus }
+      set(value) { underlyingCloseStatus = value }
     }
-    var underlyingCloseWasClean: (Bool)!
+    var underlyingCloseStatus: (CloseStatus)!
     var connectionSetCount: Int = 0
     var connectionDidGetSet: Bool { return connectionSetCount > 0 }
     override var connection: PhoenixTransport? {

--- a/Tests/SwiftPhoenixClientTests/SocketSpec.swift
+++ b/Tests/SwiftPhoenixClientTests/SocketSpec.swift
@@ -294,10 +294,10 @@ class SocketSpec: QuickSpec {
       })
       
       it("flags the socket as closed cleanly", closure: {
-        expect(socket.closeWasClean).to(beFalse())
+        expect(socket.closeStatus).to(equal(.unknown))
         
         socket.disconnect()
-        expect(socket.closeWasClean).to(beTrue())
+        expect(socket.closeStatus).to(equal(.clean))
       })
       
       it("calls callback", closure: {


### PR DESCRIPTION
## Problem

`Socket` does not correctly reconnect if the server fails to respond to a heartbeat in time, but acknowledges the subsequent client-initiated disconnection request.

## Root cause analysis

Every `heartbeatInterval` the socket tries to push a heartbeat message to the server (`sendHeartbeat`). If a response to the previous one has not been received yet (`pendingHeartbeatRef` not nil), a timeout is proclaimed. This in turn triggers an abnormal closure of the socket: `abnormalClose("heartbeat timeout")`:
```swift
if let _ = self.pendingHeartbeatRef {
  // ...
  self.abnormalClose("heartbeat timeout")
  return
}
```

The socket then closes the connection to the server with `CloseCode.normal` (1000):
```swift
internal func abnormalClose(_ reason: String) {
  self.closeWasClean = false
  
  /*
   We use NORMAL here since the client is the one determining to close the
   connection. However, we keep a flag `closeWasClean` set to false so that
   the client knows that it should attempt to reconnect.
   */
  self.connection?.disconnect(code: CloseCode.normal.rawValue, reason: reason)
}
```

The transport layer (`self.connection`) simply drops the connection (showing `URLSessionTransport`):
```swift
public func disconnect(code: Int, reason: String?) {
  // ...
  self.readyState = .closing
  self.task?.cancel(with: closeCode, reason: reason?.data(using: .utf8))
}
```

Two things can happen now:

1. Server is unreachable: the disconnection request is not processed, the transport layer reports an abnormal closure to the socket (`self.delegate`):
```swift
private func abnormalErrorReceived(_ error: Error) {
  // ...
  // An abnormal error is results in an abnormal closure, such as internet getting dropped
  // so inform the delegate that the Transport has closed abnormally. This will kick off
  // the reconnect logic.
  self.delegate?.onClose(code: Socket.CloseCode.abnormal.rawValue)
}
```

2. Server is reachable: the disconnection request is processed, the transport layer reports a closure event back to the socket (`self.delegate`), passing in the close code that was sent to the server (1000 = `CloseCode.normal`):
```swift
public func urlSession(_ session: URLSession,
                       webSocketTask: URLSessionWebSocketTask,
                       didCloseWith closeCode: URLSessionWebSocketTask.CloseCode,
                       reason: Data?) {
  // ...
  self.delegate?.onClose(code: closeCode.rawValue)
}
```

Both of these scenarios end up calling the `Socket.onClose` method:
```swift
public func onClose(code: Int) {
  self.closeWasClean = code != CloseCode.abnormal.rawValue
  self.onConnectionClosed(code: code)
}
```

In scenario 1. `self.closeWasClean` is set to `false`. In scenario 2. though, it's set to `true`, overriding the `false` value set earlier in `abnormalClose`. This in turn **causes the reconnection logic to be skipped**:
```swift
internal func onConnectionClosed(code: Int?) {
  // ...
  // Only attempt to reconnect if the socket did not close normally
  if (!self.closeWasClean) {
    self.reconnectTimer.scheduleTimeout()
  }
  // ...
}
```

## Solution

The proposed solution introduces another state variable `closingAbnormally` to be used instead of `closeWasClean` in the abnormal closure scenario. By keeping this information separately from the more generic `closeWasClean` state, `Socket` is able to tell whether a 1000 code disconnection was caused by normal operation or an abnormal condition (heartbeat timeout), and execute the reconnection logic accordingly.