### PR TITLE
Pass a response to the `onOpen` callback

### DIFF
--- a/Sources/SwiftPhoenixClient/PhoenixTransport.swift
+++ b/Sources/SwiftPhoenixClient/PhoenixTransport.swift
@@ -69,8 +69,11 @@ public protocol PhoenixTransportDelegate {
   
   /**
    Notified when the `Transport` opens.
+   
+   - Parameter handshakeProtocol: The protocol that is picked in the handshake
+   - Parameter response: Response from the server indicating that the WebSocket handshake was successful and the connection has been upgraded to webSockets
    */
-  func onOpen()
+  func onOpen(handshakeProtocol: String?, response: URLResponse?)
   
   /**
    Notified when the `Transport` receives an error.
@@ -232,7 +235,7 @@ open class URLSessionTransport: NSObject, PhoenixTransport, URLSessionWebSocketD
                        didOpenWithProtocol protocol: String?) {
     // The Websocket is connected. Set Transport state to open and inform delegate
     self.readyState = .open
-    self.delegate?.onOpen()
+    self.delegate?.onOpen(handshakeProtocol: `protocol`, response: webSocketTask.response)
     
     // Start receiving messages
     self.receive()

--- a/Sources/SwiftPhoenixClient/PhoenixTransport.swift
+++ b/Sources/SwiftPhoenixClient/PhoenixTransport.swift
@@ -71,9 +71,8 @@ public protocol PhoenixTransportDelegate {
    Notified when the `Transport` opens.
    
    - Parameter response: Response from the server indicating that the WebSocket handshake was successful and the connection has been upgraded to webSockets
-   - Parameter handshakeProtocol: The protocol that is picked in the handshake
    */
-  func onOpen(response: URLResponse?, handshakeProtocol: String?)
+  func onOpen(response: URLResponse?)
   
   /**
    Notified when the `Transport` receives an error.
@@ -232,10 +231,10 @@ open class URLSessionTransport: NSObject, PhoenixTransport, URLSessionWebSocketD
   // MARK: - URLSessionWebSocketDelegate
   open func urlSession(_ session: URLSession,
                        webSocketTask: URLSessionWebSocketTask,
-                       didOpenWithProtocol aProtocol: String?) {
+                       didOpenWithProtocol protocol: String?) {
     // The Websocket is connected. Set Transport state to open and inform delegate
     self.readyState = .open
-    self.delegate?.onOpen(response: webSocketTask.response, handshakeProtocol: aProtocol)
+    self.delegate?.onOpen(response: webSocketTask.response)
     
     // Start receiving messages
     self.receive()

--- a/Sources/SwiftPhoenixClient/PhoenixTransport.swift
+++ b/Sources/SwiftPhoenixClient/PhoenixTransport.swift
@@ -70,10 +70,10 @@ public protocol PhoenixTransportDelegate {
   /**
    Notified when the `Transport` opens.
    
-   - Parameter handshakeProtocol: The protocol that is picked in the handshake
    - Parameter response: Response from the server indicating that the WebSocket handshake was successful and the connection has been upgraded to webSockets
+   - Parameter handshakeProtocol: The protocol that is picked in the handshake
    */
-  func onOpen(handshakeProtocol: String?, response: URLResponse?)
+  func onOpen(response: URLResponse?, handshakeProtocol: String?)
   
   /**
    Notified when the `Transport` receives an error.
@@ -232,10 +232,10 @@ open class URLSessionTransport: NSObject, PhoenixTransport, URLSessionWebSocketD
   // MARK: - URLSessionWebSocketDelegate
   open func urlSession(_ session: URLSession,
                        webSocketTask: URLSessionWebSocketTask,
-                       didOpenWithProtocol protocol: String?) {
+                       didOpenWithProtocol aProtocol: String?) {
     // The Websocket is connected. Set Transport state to open and inform delegate
     self.readyState = .open
-    self.delegate?.onOpen(handshakeProtocol: `protocol`, response: webSocketTask.response)
+    self.delegate?.onOpen(response: webSocketTask.response, handshakeProtocol: aProtocol)
     
     // Start receiving messages
     self.receive()

--- a/Sources/SwiftPhoenixClient/Socket.swift
+++ b/Sources/SwiftPhoenixClient/Socket.swift
@@ -33,7 +33,7 @@ public typealias Payload = [String: Any]
 
 /// Struct that gathers callbacks assigned to the Socket
 struct StateChangeCallbacks {
-  var open: [(ref: String, callback: Delegated<(String?, URLResponse?), Void>)] = []
+  var open: [(ref: String, callback: Delegated<(URLResponse?, String?), Void>)] = []
   var close: [(ref: String, callback: Delegated<(Int, String?), Void>)] = []
   var error: [(ref: String, callback: Delegated<(Error, URLResponse?), Void>)] = []
   var message: [(ref: String, callback: Delegated<Message, Void>)] = []
@@ -268,14 +268,14 @@ public class Socket: PhoenixTransportDelegate {
   ///
   /// Example:
   ///
-  ///     socket.onOpen() { [weak self] protocol, response in
+  ///     socket.onOpen() { [weak self] response, handshakeProtocol in
   ///         self?.print("Socket Connection Open")
   ///     }
   ///
   /// - parameter callback: Called when the Socket is opened
   @discardableResult
-  public func onOpen(callback: @escaping (String?, URLResponse?) -> Void) -> String {
-    var delegated = Delegated<(String?, URLResponse?), Void>()
+  public func onOpen(callback: @escaping (URLResponse?, String?) -> Void) -> String {
+    var delegated = Delegated<(URLResponse?, String?), Void>()
     delegated.manuallyDelegate(with: callback)
     
     return self.append(callback: delegated, to: &self.stateChangeCallbacks.open)
@@ -303,7 +303,7 @@ public class Socket: PhoenixTransportDelegate {
   ///
   /// Example:
   ///
-  ///     socket.delegateOnOpen(to: self) { self, protocol, response in
+  ///     socket.delegateOnOpen(to: self) { self, response, handshakeProtocol in
   ///         self.print("Socket Connection Open")
   ///     }
   ///
@@ -311,8 +311,8 @@ public class Socket: PhoenixTransportDelegate {
   /// - parameter callback: Called when the Socket is opened
   @discardableResult
   public func delegateOnOpen<T: AnyObject>(to owner: T,
-                                           callback: @escaping ((T, (String?, URLResponse?)) -> Void)) -> String {
-    var delegated = Delegated<(String?, URLResponse?), Void>()
+                                           callback: @escaping ((T, (URLResponse?, String?)) -> Void)) -> String {
+    var delegated = Delegated<(URLResponse?, String?), Void>()
     delegated.delegate(to: owner, with: callback)
     
     return self.append(callback: delegated, to: &self.stateChangeCallbacks.open)
@@ -584,7 +584,7 @@ public class Socket: PhoenixTransportDelegate {
   // MARK: - Connection Events
   //----------------------------------------------------------------------
   /// Called when the underlying Websocket connects to it's host
-  internal func onConnectionOpen(handshakeProtocol: String?, response: URLResponse?) {
+  internal func onConnectionOpen(response: URLResponse?, handshakeProtocol: String?) {
     self.logItems("transport", "Connected to \(endPoint)")
     
     // Reset the close status now that the socket has been connected
@@ -600,7 +600,7 @@ public class Socket: PhoenixTransportDelegate {
     self.resetHeartbeat()
     
     // Inform all onOpen callbacks that the Socket has opened
-    self.stateChangeCallbacks.open.forEach({ $0.callback.call((handshakeProtocol, response)) })
+    self.stateChangeCallbacks.open.forEach({ $0.callback.call((response, handshakeProtocol)) })
   }
   
   internal func onConnectionClosed(code: Int, reason: String?) {
@@ -788,8 +788,8 @@ public class Socket: PhoenixTransportDelegate {
   //----------------------------------------------------------------------
   // MARK: - TransportDelegate
   //----------------------------------------------------------------------
-  public func onOpen(handshakeProtocol: String?, response: URLResponse?) {
-    self.onConnectionOpen(handshakeProtocol: handshakeProtocol, response: response)
+  public func onOpen(response: URLResponse?, handshakeProtocol: String?) {
+      self.onConnectionOpen(response: response, handshakeProtocol: handshakeProtocol)
   }
   
   public func onError(error: Error, response: URLResponse?) {

--- a/Sources/SwiftPhoenixClient/Socket.swift
+++ b/Sources/SwiftPhoenixClient/Socket.swift
@@ -33,7 +33,7 @@ public typealias Payload = [String: Any]
 
 /// Struct that gathers callbacks assigned to the Socket
 struct StateChangeCallbacks {
-  var open: [(ref: String, callback: Delegated<(URLResponse?, String?), Void>)] = []
+  var open: [(ref: String, callback: Delegated<(URLResponse?), Void>)] = []
   var close: [(ref: String, callback: Delegated<(Int, String?), Void>)] = []
   var error: [(ref: String, callback: Delegated<(Error, URLResponse?), Void>)] = []
   var message: [(ref: String, callback: Delegated<Message, Void>)] = []
@@ -260,7 +260,7 @@ public class Socket: PhoenixTransportDelegate {
   /// - parameter callback: Called when the Socket is opened
   @discardableResult
   public func onOpen(callback: @escaping () -> Void) -> String {
-    return self.onOpen { _, _ in callback() }
+    return self.onOpen { _ in callback() }
   }
   
   /// Registers callbacks for connection open events. Does not handle retain
@@ -268,14 +268,14 @@ public class Socket: PhoenixTransportDelegate {
   ///
   /// Example:
   ///
-  ///     socket.onOpen() { [weak self] response, handshakeProtocol in
+  ///     socket.onOpen() { [weak self] response in
   ///         self?.print("Socket Connection Open")
   ///     }
   ///
   /// - parameter callback: Called when the Socket is opened
   @discardableResult
-  public func onOpen(callback: @escaping (URLResponse?, String?) -> Void) -> String {
-    var delegated = Delegated<(URLResponse?, String?), Void>()
+  public func onOpen(callback: @escaping (URLResponse?) -> Void) -> String {
+    var delegated = Delegated<(URLResponse?), Void>()
     delegated.manuallyDelegate(with: callback)
     
     return self.append(callback: delegated, to: &self.stateChangeCallbacks.open)
@@ -303,7 +303,7 @@ public class Socket: PhoenixTransportDelegate {
   ///
   /// Example:
   ///
-  ///     socket.delegateOnOpen(to: self) { self, response, handshakeProtocol in
+  ///     socket.delegateOnOpen(to: self) { self, response in
   ///         self.print("Socket Connection Open")
   ///     }
   ///
@@ -311,8 +311,8 @@ public class Socket: PhoenixTransportDelegate {
   /// - parameter callback: Called when the Socket is opened
   @discardableResult
   public func delegateOnOpen<T: AnyObject>(to owner: T,
-                                           callback: @escaping ((T, (URLResponse?, String?)) -> Void)) -> String {
-    var delegated = Delegated<(URLResponse?, String?), Void>()
+                                           callback: @escaping ((T, (URLResponse?)) -> Void)) -> String {
+    var delegated = Delegated<(URLResponse?), Void>()
     delegated.delegate(to: owner, with: callback)
     
     return self.append(callback: delegated, to: &self.stateChangeCallbacks.open)
@@ -584,7 +584,7 @@ public class Socket: PhoenixTransportDelegate {
   // MARK: - Connection Events
   //----------------------------------------------------------------------
   /// Called when the underlying Websocket connects to it's host
-  internal func onConnectionOpen(response: URLResponse?, handshakeProtocol: String?) {
+  internal func onConnectionOpen(response: URLResponse?) {
     self.logItems("transport", "Connected to \(endPoint)")
     
     // Reset the close status now that the socket has been connected
@@ -600,7 +600,7 @@ public class Socket: PhoenixTransportDelegate {
     self.resetHeartbeat()
     
     // Inform all onOpen callbacks that the Socket has opened
-    self.stateChangeCallbacks.open.forEach({ $0.callback.call((response, handshakeProtocol)) })
+    self.stateChangeCallbacks.open.forEach({ $0.callback.call((response)) })
   }
   
   internal func onConnectionClosed(code: Int, reason: String?) {
@@ -788,8 +788,8 @@ public class Socket: PhoenixTransportDelegate {
   //----------------------------------------------------------------------
   // MARK: - TransportDelegate
   //----------------------------------------------------------------------
-  public func onOpen(response: URLResponse?, handshakeProtocol: String?) {
-      self.onConnectionOpen(response: response, handshakeProtocol: handshakeProtocol)
+  public func onOpen(response: URLResponse?) {
+      self.onConnectionOpen(response: response)
   }
   
   public func onError(error: Error, response: URLResponse?) {

--- a/Sources/SwiftPhoenixClient/Socket.swift
+++ b/Sources/SwiftPhoenixClient/Socket.swift
@@ -789,7 +789,7 @@ public class Socket: PhoenixTransportDelegate {
   // MARK: - TransportDelegate
   //----------------------------------------------------------------------
   public func onOpen(response: URLResponse?) {
-      self.onConnectionOpen(response: response)
+    self.onConnectionOpen(response: response)
   }
   
   public func onError(error: Error, response: URLResponse?) {

--- a/Sources/SwiftPhoenixClient/Socket.swift
+++ b/Sources/SwiftPhoenixClient/Socket.swift
@@ -33,7 +33,7 @@ public typealias Payload = [String: Any]
 
 /// Struct that gathers callbacks assigned to the Socket
 struct StateChangeCallbacks {
-  var open: [(ref: String, callback: Delegated<Void, Void>)] = []
+  var open: [(ref: String, callback: Delegated<(String?, URLResponse?), Void>)] = []
   var close: [(ref: String, callback: Delegated<(Int, String?), Void>)] = []
   var error: [(ref: String, callback: Delegated<(Error, URLResponse?), Void>)] = []
   var message: [(ref: String, callback: Delegated<Message, Void>)] = []
@@ -260,7 +260,22 @@ public class Socket: PhoenixTransportDelegate {
   /// - parameter callback: Called when the Socket is opened
   @discardableResult
   public func onOpen(callback: @escaping () -> Void) -> String {
-    var delegated = Delegated<Void, Void>()
+    return self.onOpen { _, _ in callback() }
+  }
+  
+  /// Registers callbacks for connection open events. Does not handle retain
+  /// cycles. Use `delegateOnOpen(to:)` for automatic handling of retain cycles.
+  ///
+  /// Example:
+  ///
+  ///     socket.onOpen() { [weak self] protocol, response in
+  ///         self?.print("Socket Connection Open")
+  ///     }
+  ///
+  /// - parameter callback: Called when the Socket is opened
+  @discardableResult
+  public func onOpen(callback: @escaping (String?, URLResponse?) -> Void) -> String {
+    var delegated = Delegated<(String?, URLResponse?), Void>()
     delegated.manuallyDelegate(with: callback)
     
     return self.append(callback: delegated, to: &self.stateChangeCallbacks.open)
@@ -280,7 +295,24 @@ public class Socket: PhoenixTransportDelegate {
   @discardableResult
   public func delegateOnOpen<T: AnyObject>(to owner: T,
                                            callback: @escaping ((T) -> Void)) -> String {
-    var delegated = Delegated<Void, Void>()
+    return self.delegateOnOpen(to: owner) { owner, _ in callback(owner) }
+  }
+
+  /// Registers callbacks for connection open events. Automatically handles
+  /// retain cycles. Use `onOpen()` to handle yourself.
+  ///
+  /// Example:
+  ///
+  ///     socket.delegateOnOpen(to: self) { self, protocol, response in
+  ///         self.print("Socket Connection Open")
+  ///     }
+  ///
+  /// - parameter owner: Class registering the callback. Usually `self`
+  /// - parameter callback: Called when the Socket is opened
+  @discardableResult
+  public func delegateOnOpen<T: AnyObject>(to owner: T,
+                                           callback: @escaping ((T, (String?, URLResponse?)) -> Void)) -> String {
+    var delegated = Delegated<(String?, URLResponse?), Void>()
     delegated.delegate(to: owner, with: callback)
     
     return self.append(callback: delegated, to: &self.stateChangeCallbacks.open)
@@ -552,7 +584,7 @@ public class Socket: PhoenixTransportDelegate {
   // MARK: - Connection Events
   //----------------------------------------------------------------------
   /// Called when the underlying Websocket connects to it's host
-  internal func onConnectionOpen() {
+  internal func onConnectionOpen(handshakeProtocol: String?, response: URLResponse?) {
     self.logItems("transport", "Connected to \(endPoint)")
     
     // Reset the close status now that the socket has been connected
@@ -568,7 +600,7 @@ public class Socket: PhoenixTransportDelegate {
     self.resetHeartbeat()
     
     // Inform all onOpen callbacks that the Socket has opened
-    self.stateChangeCallbacks.open.forEach({ $0.callback.call() })
+    self.stateChangeCallbacks.open.forEach({ $0.callback.call((handshakeProtocol, response)) })
   }
   
   internal func onConnectionClosed(code: Int, reason: String?) {
@@ -756,8 +788,8 @@ public class Socket: PhoenixTransportDelegate {
   //----------------------------------------------------------------------
   // MARK: - TransportDelegate
   //----------------------------------------------------------------------
-  public func onOpen() {
-    self.onConnectionOpen()
+  public func onOpen(handshakeProtocol: String?, response: URLResponse?) {
+    self.onConnectionOpen(handshakeProtocol: handshakeProtocol, response: response)
   }
   
   public func onError(error: Error, response: URLResponse?) {


### PR DESCRIPTION
## Background

For the Cloudflare investigation, we want to log `CF-RAY` header from the handshake response.

From @arkgil:
> [8:08 PM](https://whatnot.slack.com/archives/C05B44NPH5W/p1686161317894179)
Cloudflare keeps asking for Ray IDs of WebSocket connections so that they can debug if there are disconnections. When I provided those to them last time they weren’t very helpful, but maybe worth considering it as an addition to the monitoring stack. The apps would need to extract the cf-ray header from WebSocket handshake response and add it to the logs, not sure how difficult that is with the Phoenix libraries. 

## Changes

* Add `onOpen` and `delegateOnOpen' versions that pass a handshake response.
* Original `onOpen` and `delegateOnOpen' are still there – the change is backward compatible.

## Testing

* Tested in the app in [this PR](https://github.com/Whatnot-Inc/whatnot-ios/pull/6146).

## Other considerations

I may want to try and push these changes to the SwiftPhoenixClient branch.