### PR TITLE
Track push time

### DIFF
--- a/Sources/SwiftPhoenixClient/Push.swift
+++ b/Sources/SwiftPhoenixClient/Push.swift
@@ -37,6 +37,9 @@ public class Push {
   /// The push timeout. Default is 10.0 seconds
   public var timeout: TimeInterval
   
+  /// Time interval between sending the push and receiving a response
+  public private(set) var roundTripTime: TimeInterval?
+  
   /// The server's response to the Push
   var receivedMessage: Message?
   
@@ -58,6 +61,8 @@ public class Push {
   /// The event that is associated with the reference ID of the Push
   var refEvent: String?
   
+  /// Date push was sent to server
+  private var sentToServerDate: Date?
   
   
   /// Initializes a Push
@@ -104,7 +109,9 @@ public class Push {
       payload: self.payload,
       ref: self.ref,
       joinRef: channel?.joinRef
-    )
+    ) { [weak self] in
+        self?.sentToServerDate = Date()
+    }
   }
   
   /// Receive a specific event when sending an Outbound message. Subscribing
@@ -232,6 +239,7 @@ public class Push {
       self.cancelRefEvent()
       self.cancelTimeout()
       self.receivedMessage = message
+      self.roundTripTime = self.sentToServerDate.flatMap { Date().timeIntervalSince($0) }
       
       /// Check if there is event a status available
       guard let status = message.status else { return }

--- a/Sources/SwiftPhoenixClient/Push.swift
+++ b/Sources/SwiftPhoenixClient/Push.swift
@@ -192,6 +192,8 @@ public class Push {
     self.refEvent = nil
     self.receivedMessage = nil
     self.sent = false
+    self.sentToServerDate = nil
+    self.roundTripTime = nil
   }
   
   

--- a/Sources/SwiftPhoenixClient/Socket.swift
+++ b/Sources/SwiftPhoenixClient/Socket.swift
@@ -542,11 +542,13 @@ public class Socket: PhoenixTransportDelegate {
   /// - parameter payload:
   /// - parameter ref: Optional. Defaults to nil
   /// - parameter joinRef: Optional. Defaults to nil
+  /// - parameter didSendDataToServer: Called when the data has been sent to the server
   internal func push(topic: String,
                      event: String,
                      payload: Payload,
                      ref: String? = nil,
-                     joinRef: String? = nil) {
+                     joinRef: String? = nil,
+                     didSendDataToServer: (() -> Void)? = nil) {
     
     let callback: (() throws -> ()) = {
       let body: [Any?] = [joinRef, ref, topic, event, payload]
@@ -554,6 +556,7 @@ public class Socket: PhoenixTransportDelegate {
       
       self.logItems("push", "Sending \(String(data: data, encoding: String.Encoding.utf8) ?? "")" )
       self.connection?.send(data: data)
+      didSendDataToServer?()
     }
     
     /// If the socket is connected, then execute the callback immediately.


### PR DESCRIPTION
## Background

To fix [the drift time issue](https://docs.google.com/document/d/1H6gw1QyX1j3Vc8MG-jf4tF9jNSEx5EPked6zmw1RHtM/edit) we want to track round trip time of push messages. 

## Changes

* Add a callback to socket `push` method triggered when push is actually sent to the server.
* Store a date when the push is sent to the server.
* Calculate the round trip and allow using it from a property.

## Testing/validation

It builds.