### PR TITLE
Accept additional payload for the leave command

### DIFF
--- a/Sources/SwiftPhoenixClient/Channel.swift
+++ b/Sources/SwiftPhoenixClient/Channel.swift
@@ -480,14 +480,10 @@ public class Channel {
   ////
   ///     channel.leave().receive("ok") { _ in { print("left") }
   ///
-  /// - parameter payload: Optional payload to pass along with the event
   /// - parameter timeout: Optional timeout
   /// - return: Push that can add receive hooks
   @discardableResult
-  public func leave(
-    payload: Payload = [:],
-    timeout: TimeInterval = Defaults.timeoutInterval
-  ) -> Push {
+  public func leave(timeout: TimeInterval = Defaults.timeoutInterval) -> Push {
     // If attempting a rejoin during a leave, then reset, cancelling the rejoin
     self.rejoinTimer.reset()
     
@@ -506,7 +502,7 @@ public class Channel {
     // Push event to send to the server
     let leavePush = Push(channel: self,
                          event: ChannelEvent.leave,
-                         payload: payload,
+                         payload: params,
                          timeout: timeout)
     
     // Perform the same behavior if successfully left the channel

--- a/Sources/SwiftPhoenixClient/Channel.swift
+++ b/Sources/SwiftPhoenixClient/Channel.swift
@@ -479,10 +479,14 @@ public class Channel {
   ////
   ///     channel.leave().receive("ok") { _ in { print("left") }
   ///
+  /// - parameter payload: Optional payload to pass along with the event
   /// - parameter timeout: Optional timeout
   /// - return: Push that can add receive hooks
   @discardableResult
-  public func leave(timeout: TimeInterval = Defaults.timeoutInterval) -> Push {
+  public func leave(
+    payload: Payload = [:],
+    timeout: TimeInterval = Defaults.timeoutInterval
+  ) -> Push {
     // If attempting a rejoin during a leave, then reset, cancelling the rejoin
     self.rejoinTimer.reset()
     
@@ -501,6 +505,7 @@ public class Channel {
     // Push event to send to the server
     let leavePush = Push(channel: self,
                          event: ChannelEvent.leave,
+                         payload: payload,
                          timeout: timeout)
     
     // Perform the same behavior if successfully left the channel

--- a/Sources/SwiftPhoenixClient/Channel.swift
+++ b/Sources/SwiftPhoenixClient/Channel.swift
@@ -63,7 +63,7 @@ public class Channel {
   /// The topic of the Channel. e.g. "rooms:friends"
   public let topic: String
   
-  /// The params sent when joining the channel
+  /// The params sent when joining and leaving the channel
   public var params: Payload {
     didSet { self.joinPush.payload = params }
   }

--- a/Sources/SwiftPhoenixClient/Channel.swift
+++ b/Sources/SwiftPhoenixClient/Channel.swift
@@ -172,6 +172,7 @@ public class Channel {
       // Send a Push to the server to leave the channel
       let leavePush = Push(channel: self,
                            event: ChannelEvent.leave,
+                           payload: params,
                            timeout: self.timeout)
       leavePush.send()
       


### PR DESCRIPTION
The data team asked us to pass an additional `isCheckoutImplementation` parameter to the Live Service, both when joining and leaving the auction channel, in order to treat that as a synthetic livestream join and conversely exclude it from some charts.

This PR makes it possible to pass arbitrary payloads when leaving a channel (already supported for join events).

More context: https://whatnot.slack.com/archives/C023P728AKV/p1696933078616719